### PR TITLE
Join table error caused by mismatched table name

### DIFF
--- a/app/models/refinery/dynamicfields/dynamicform_value.rb
+++ b/app/models/refinery/dynamicfields/dynamicform_value.rb
@@ -9,7 +9,7 @@ module Refinery
       belongs_to :resource, :class_name => '::Refinery::Resource'
 
 			def self.find_by_page_and_field_id(page_id, field_id)
-		    self.joins(:dynamicform_association, :dynamicform_field).where("dynamicform_associations.page_id" => page_id, "dynamicform_fields.field_id" => field_id).first
+		    self.joins(:dynamicform_association, :dynamicform_field).where("#{::Refinery::Dynamicfields::DynamicformAssociation.table_name}.page_id" => page_id, "#{::Refinery::Dynamicfields::DynamicformField.table_name}.field_id" => field_id).first
 		  end
 		end
 	end


### PR DESCRIPTION
A recent commit changed the table names in the migration to be prepended with the refinery syntax. The where query in the value model still references the old table name. This pull request allows Rails to dynamically fetch the table name which solves the above issue and also allows for the table name to be changed in the future without affecting this functionality.
